### PR TITLE
[#9] Add Duration of DAG Runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 0.3 - Unreleased
+## 0.3 - 2018-09-12
 
-- [#11](https://github.com/epoch8/airflow-exporter/pull/11): Added metric for duration of DagRuns
+- [#11](https://github.com/epoch8/airflow-exporter/pull/11): Added metric for duration of DagRuns by @hydrosquall
 
 ## 0.2 - 2018-09-10 more labels
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.3 - Unreleased
+
+- [#11](https://github.com/epoch8/airflow-exporter/pull/11): Added metric for duration of DagRuns
+
 ## 0.2 - 2018-09-10 more labels
 
 Added:
@@ -8,4 +12,3 @@ Added:
 - explicit 0 metric for each state in `dag_status`
 
 ## 0.1 - 2018-08-07 initial release
-

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Labels:
 
 Value: number of dags in specific status.
 
+### `airflow_dag_run_duration`
+
+Labels:
+
+* `dag_id`: unique identifier for a given DAG
+* `run_id`: unique identifier created each time a DAG is run
+
+Value: duration in seconds that a DAG Run has been running for. This metric is not available for DAGs that have already completed.
+
 ## License
 
 Distributed under the BSD license. See [LICENSE](LICENSE) for more

--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -9,8 +9,8 @@ from prometheus_exporter.db.store import get_context
 from sqlalchemy import func
 import copy
 from airflow.www.app import csrf
-from airflow.models import DagStat, TaskInstance, DagModel
-
+from airflow.models import DagStat, TaskInstance, DagModel, DagRun
+from airflow.utils.state import State
 
 
 @get_context()
@@ -44,11 +44,32 @@ def get_task_state_info(connection):
     ).join(DagModel, DagModel.dag_id == task_status_query.c.dag_id).all()
 
 
+@get_context()
+def get_dag_duration_info(connection):
+    '''get duration of currently running DagRuns
+    :param connection: session in db
+    :return dag_info
+    '''
+    duration = func.sum(func.now() - DagRun.start_date)
+
+    return connection.query(
+        DagRun.dag_id,
+        DagRun.run_id,
+        duration.label('duration')
+    ).group_by(
+        DagRun.dag_id,
+        DagRun.run_id
+    ).filter(
+        DagRun.state == State.RUNNING
+    ).all()
+
 
 class MetricsCollector(object):
     '''collection of metrics for prometheus'''
     def collect(self):
         '''collect metrics'''
+
+        # Task metrics
         task_info = get_task_state_info()
         t_state = GaugeMetricFamily(
             'airflow_task_status',
@@ -59,6 +80,7 @@ class MetricsCollector(object):
             t_state.add_metric([task.dag_id, task.task_id, task.owners, task.state], task.value)
         yield copy.copy(t_state)
 
+        # Dag Metrics
         dag_info = get_dag_state_info()
         d_state = GaugeMetricFamily(
             'airflow_dag_status',
@@ -68,6 +90,17 @@ class MetricsCollector(object):
         for dag in dag_info:
             d_state.add_metric([dag.dag_id, dag.owners, dag.state], dag.count)
         yield d_state
+
+        # DagRun metrics
+        dag_duration = GaugeMetricFamily(
+            'airflow_dag_run_duration',
+            'Duration of currently running dag_runs in seconds',
+            labels=['dag_id', 'run_id']
+        )
+        for dag in get_dag_duration_info():
+            dag_duration.add_metric([dag.dag_id, dag.run_id], dag.duration.seconds)
+        yield dag_duration
+
 
 
 REGISTRY.register(MetricsCollector())


### PR DESCRIPTION
This targets feature request #9. It Reports the duration that currently running DagRuns have been running for.

This can be used when people are trying to alert based on DagRuns that have gone on longer than expected.