### PR TITLE
Set up continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+env:
+  - DOCKER_COMPOSE_VERSION=1.9.0
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+script:
+  - cd tests/airflow1.8-py2 && docker-compose up -d
+  - curl http://localhost:8080/admin/metrics

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   global:
     - DOCKER_COMPOSE_VERSION=1.9.0
     - AIRFLOW_SLEEP_DURATION=60 # Number of seconds to wait for airflow to start
+    - METRICS_ENDPOINT=http://localhost:8080/admin/metrics/
+    - CURL_FLAGS=--show-error --fail
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -20,12 +22,12 @@ script:
 
   # Test Airflow 1.8 with Python 2
   - cd tests/airflow1.8-py2 && docker-compose up -d
-  - pwd && sleep ${AIRFLOW_SLEEP_DURATION}
-  - curl http://localhost:8080/admin/metrics/
+  - sleep ${AIRFLOW_SLEEP_DURATION}
+  - curl ${CURL_FLAGS} ${METRICS_ENDPOINT}
   - docker-compose down
 
   # Test Airflow 1.9 with Python 3
   - cd ../../tests/airflow1.9-py3 && docker-compose up -d
-  - pwd && sleep ${AIRFLOW_SLEEP_DURATION}
-  - curl http://localhost:8080/admin/metrics/
+  - sleep ${AIRFLOW_SLEEP_DURATION}
+  - curl ${CURL_FLAGS} ${METRICS_ENDPOINT}
   - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 
 services:
   - docker
@@ -16,14 +16,15 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - chmod +x tests/test_metrics_up.sh
+  
 
 script:
   # Test Airflow 1.8 with Python 2
   - cd tests/airflow1.8-py2 && docker-compose up -d
-  - ../${INTEGRATION_TEST_SCRIPT}
+  - ${TRAVIS_BUILD_DIR}/tests/${INTEGRATION_TEST_SCRIPT}
   - docker-compose down
 
   # Test Airflow 1.9 with Python 3
-  - cd ../../tests/airflow1.9-py3 && docker-compose up -d
-  - ../${INTEGRATION_TEST_SCRIPT}
+  - cd ${TRAVIS_BUILD_DIR}/tests/airflow1.9-py3 && docker-compose up -d
+  - ${TRAVIS_BUILD_DIR}/tests/${INTEGRATION_TEST_SCRIPT}
   - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,22 @@ services:
 env:
   global:
     - DOCKER_COMPOSE_VERSION=1.9.0
-    - AIRFLOW_SLEEP_DURATION=60 # Number of seconds to wait for airflow to start
-    - METRICS_ENDPOINT=http://localhost:8080/admin/metrics/
-    - CURL_FLAGS=--show-error --fail
-
+    - INTEGRATION_TEST_SCRIPT=test_metrics_up.sh
+    
 before_install:
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - chmod +x tests/test_metrics_up.sh
 
 script:
-
   # Test Airflow 1.8 with Python 2
   - cd tests/airflow1.8-py2 && docker-compose up -d
-  - sleep ${AIRFLOW_SLEEP_DURATION}
-  - curl ${CURL_FLAGS} ${METRICS_ENDPOINT}
+  - ../${INTEGRATION_TEST_SCRIPT}
   - docker-compose down
 
   # Test Airflow 1.9 with Python 3
   - cd ../../tests/airflow1.9-py3 && docker-compose up -d
-  - sleep ${AIRFLOW_SLEEP_DURATION}
-  - curl ${CURL_FLAGS} ${METRICS_ENDPOINT}
+  - ../${INTEGRATION_TEST_SCRIPT}
   - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ services:
 # Docker-compose setup
 # https://docs.travis-ci.com/user/docker/
 env:
-  - DOCKER_COMPOSE_VERSION=1.9.0
-  - AIRFLOW_SLEEP_DURATION=60 # Number of seconds to wait for airflow to start
+  global:
+    - DOCKER_COMPOSE_VERSION=1.9.0
+    - AIRFLOW_SLEEP_DURATION=60 # Number of seconds to wait for airflow to start
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
+sudo: required
+
+services:
+  - docker
+
+# Docker-compose setup
+# https://docs.travis-ci.com/user/docker/
 env:
   - DOCKER_COMPOSE_VERSION=1.9.0
+  - AIRFLOW_SLEEP_DURATION=60 # Number of seconds to wait for airflow to start
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -8,6 +16,15 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 script:
+
+  # Test Airflow 1.8 with Python 2
   - cd tests/airflow1.8-py2 && docker-compose up -d
-  - pwd && sleep 30 # not sure how to dynamically wait
-  - curl http://localhost:8080/admin/metrics
+  - pwd && sleep ${AIRFLOW_SLEEP_DURATION}
+  - curl http://localhost:8080/admin/metrics/
+  - docker-compose down
+
+  # Test Airflow 1.9 with Python 3
+  - cd ../../tests/airflow1.9-py3 && docker-compose up -d
+  - pwd && sleep ${AIRFLOW_SLEEP_DURATION}
+  - curl http://localhost:8080/admin/metrics/
+  - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ before_install:
 
 script:
   - cd tests/airflow1.8-py2 && docker-compose up -d
+  - pwd && sleep 30 # not sure how to dynamically wait
   - curl http://localhost:8080/admin/metrics

--- a/tests/airflow1.8-py2/docker-compose.yml
+++ b/tests/airflow1.8-py2/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '2'
 
-
 services:
     
     exporter_postgresql:

--- a/tests/airflow1.9-py3/airflow/build/Dockerfile
+++ b/tests/airflow1.9-py3/airflow/build/Dockerfile
@@ -4,7 +4,5 @@ USER root
 
 RUN pip3 install prometheus_client
 
-# RUN mkdir -p /usr/local/airflow/logs && chown airflow -R /usr/local/airflow/logs
-# # RUN chown -R airflow /usr/local/airflow
-
-# USER airflow
+# Needed to write to mounted directory with proper permissions
+USER ${HOST_USER_ID}

--- a/tests/airflow1.9-py3/airflow/build/Dockerfile
+++ b/tests/airflow1.9-py3/airflow/build/Dockerfile
@@ -4,4 +4,7 @@ USER root
 
 RUN pip3 install prometheus_client
 
-USER airflow
+# RUN mkdir -p /usr/local/airflow/logs && chown airflow -R /usr/local/airflow/logs
+# # RUN chown -R airflow /usr/local/airflow
+
+# USER airflow

--- a/tests/airflow1.9-py3/docker-compose.yml
+++ b/tests/airflow1.9-py3/docker-compose.yml
@@ -24,6 +24,7 @@ services:
             - POSTGRES_USER=airflow
             - POSTGRES_PASSWORD=airflowpass
             - POSTGRES_DB=airflow
+            - HOST_USER_ID=$UID # need to write to mounted files
         volumes:
             - ../dags:/usr/local/airflow/dags
             - ../..:/usr/local/airflow/plugins/airflow-exporter-0.000

--- a/tests/test_metrics_up.sh
+++ b/tests/test_metrics_up.sh
@@ -13,7 +13,7 @@ CURL_FLAGS="--show-error --fail"
 
 echo "Waiting ${AIRFLOW_SLEEP_DURATION} seconds for Airflow to start before pinging"
 sleep ${AIRFLOW_SLEEP_DURATION}
-curl ${CURL_FLAGS} --silent ${ADMIN_ENDPOINT} && echo 'Admin console is up'
+curl ${CURL_FLAGS} --silent --output /dev/null ${ADMIN_ENDPOINT} && echo 'Admin console is up'
 curl ${CURL_FLAGS} ${METRICS_ENDPOINT}
 
 # TODO: validate the contents of the CURLed data

--- a/tests/test_metrics_up.sh
+++ b/tests/test_metrics_up.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Integration test that
+# 1. Waits for Airflow to come up within 60 seconds
+# 2. Ensures the Metrics endpoint returned a valid response
+# Depends on Curl
+
+AIRFLOW_SLEEP_DURATION=70 # Number of seconds to wait for airflow to start
+METRICS_ENDPOINT="http://localhost:8080/admin/metrics/"
+
+# Return nonzero status code if endpoint does not return 200
+CURL_FLAGS="--show-error --fail"
+
+sleep ${AIRFLOW_SLEEP_DURATION}
+curl ${CURL_FLAGS} ${METRICS_ENDPOINT}
+
+# TODO: validate the contents of the CURLed data

--- a/tests/test_metrics_up.sh
+++ b/tests/test_metrics_up.sh
@@ -4,13 +4,16 @@
 # 2. Ensures the Metrics endpoint returned a valid response
 # Depends on Curl
 
-AIRFLOW_SLEEP_DURATION=70 # Number of seconds to wait for airflow to start
+AIRFLOW_SLEEP_DURATION=90 # Number of seconds to wait for airflow to start
+ADMIN_ENDPOINT="http://localhost:8080/admin/"
 METRICS_ENDPOINT="http://localhost:8080/admin/metrics/"
 
 # Return nonzero status code if endpoint does not return 200
 CURL_FLAGS="--show-error --fail"
 
+echo "Waiting ${AIRFLOW_SLEEP_DURATION} seconds for Airflow to start before pinging"
 sleep ${AIRFLOW_SLEEP_DURATION}
+curl ${CURL_FLAGS} --silent ${ADMIN_ENDPOINT} && echo 'Admin console is up'
 curl ${CURL_FLAGS} ${METRICS_ENDPOINT}
 
 # TODO: validate the contents of the CURLed data


### PR DESCRIPTION
- Sets up a basic integration test as requested in #13 
- Unclear to me whether the failures in python3 is an issue with the CI setup, or a genuine incompatibility with Airflow 1.9. (You can check the logs yourself and decide: https://travis-ci.org/hydrosquall/airflow-exporter/builds/442006992)

Things to watch out for:

- I have to run the Airflow1.9 test as a root user, because for some reason Airflow Webserver seems to be writing logs with a different user than it was doing in Airflow1.8.

Based on the travis log messages when running in non-detached mode, I believe the issue is that the user inside the container is unable to create new folders on the host machine. ([example, search for permission denied](https://travis-ci.org/hydrosquall/airflow-exporter/builds/442006205)).

I tried a couple different options to get around this issue, but this seemed like the cleanest.

Other possible extras:

- Do we want to be stricter about what constitutes "valid" input besides returning 200 status code? (A strict text match doesn't make sense since the memory values would be a little different every time). I think there's room to improve, but that this could still help as a first-pass.

- Does epoch8 have an organization Travis account? For now I'm running the CI jobs on my personal account, but you can use this same config file to tie the tests into your organization account: https://travis-ci.org/hydrosquall/airflow-exporter



