### PR TITLE
Add support to show prometheus metrics when rbac is enabled in airflow

### DIFF
--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -3,6 +3,10 @@ from sqlalchemy import func
 from flask import Response
 from flask_admin import BaseView, expose
 
+# Views for Flask App Builder
+from flask_appbuilder import BaseView as FABBaseView, expose as FABexpose
+
+
 from airflow.plugins_manager import AirflowPlugin
 from airflow.settings import Session
 from airflow.models import DagStat, TaskInstance, DagModel, DagRun
@@ -127,6 +131,20 @@ class Metrics(BaseView):
 
 ADMIN_VIEW = Metrics(category="Prometheus exporter", name="metrics")
 
+class RBACMetrics(FABBaseView):
+    route_base = "/metrics/"
+    @FABexpose('/')
+    def list(self):
+        return Response(generate_latest(), mimetype='text')
+
+
+# Metrics View for Flask app builder used in airflow with rbac enabled
+RBACmetricsView = {
+    "view": RBACMetrics(),
+    "name": "metrics",
+    "category": "Prometheus exporter"
+}
+
 
 class AirflowPrometheusPlugins(AirflowPlugin):
     '''plugin for show metrics'''
@@ -138,3 +156,5 @@ class AirflowPrometheusPlugins(AirflowPlugin):
     admin_views = [ADMIN_VIEW]
     flask_blueprints = []
     menu_links = []
+    appbuilder_views = [RBACmetricsView]
+    appbuilder_menu_items = []


### PR DESCRIPTION
This enables prometheus metrics view on airflow when rbac is enabled.
Support for plugins in rbac is not available in release 1.10. This will be available in dev/future releases of airflow.