### PR TITLE
Fix negative val for airflow_dag_run_duration

### DIFF
--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -92,10 +92,10 @@ def get_dag_duration_info():
         'pysqlite': func.sum(
             (func.julianday(func.current_timestamp()) - func.julianday(DagRun.start_date)) * 86400.0
         ),
-        'mysqldb': func.sum(func.timestampdiff(text('second'), func.now(), DagRun.start_date)),
+        'mysqldb': func.sum(func.timestampdiff(text('second'), DagRun.start_date, func.now())),
         'default': func.sum(func.now() - DagRun.start_date)
     }
-    duration = durations.get(driver, durations['default']) 
+    duration = durations.get(driver, durations['default'])
 
     with session_scope(Session) as session:
         return session.query(


### PR DESCRIPTION
When using MySQL the value is negative:

```
# HELP airflow_dag_run_duration Duration of currently running dag_runs in seconds
# TYPE airflow_dag_run_duration gauge
airflow_dag_run_duration{dag_id="dummy_dag",run_id="manual__2018-12-10T15:01:47.297748+00:00"} -2.0
```
This addresses this issue.