### PR TITLE
Fix import error for dummy operator

### DIFF
--- a/tests/dags/dummy_dag.py
+++ b/tests/dags/dummy_dag.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from airflow import DAG
-from airflow.operators import DummyOperator
+from airflow.operators.dummy_operator import DummyOperator
 
 
 default_args = {


### PR DESCRIPTION
To fix below error

```[2018-12-17 18:20:02,045] {plugins_manager.py:101} ERROR - Failed to import plugin /Users/sumitm/airflow/plugins/prometheus_exporter/prometheus_exporter.py
[2018-12-17 18:20:02,048] {plugins_manager.py:100} ERROR - cannot import name 'DummyOperator'
Traceback (most recent call last):
  File "/Users/sumitm/work/incubator-airflow/airflow/plugins_manager.py", line 89, in <module>
    m = imp.load_source(namespace, filepath)
  File "/Users/sumitm/work/incubator-airflow/venv3/lib/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/sumitm/airflow/plugins/prometheus_exporter/tests/dags/dummy_dag.py", line 3, in <module>
    from airflow.operators import DummyOperator
ImportError: cannot import name 'DummyOperator'```