### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ That's it. You're done.
 Metrics will be available at 
 
 ```
-http://<your_airflow_host_and_port>/admin/metrics
+http://<your_airflow_host_and_port>/admin/metrics/
 ```
 
 ### `airflow_task_status`


### PR DESCRIPTION
Default path `/admin/metrics/`.
If using `/admin/metrics` then airflow redirect to `/admin/metrics/` but if used nginx for proxy with ssl then scraping return error 400 in prometheus.