### PR TITLE
Add airflow_task_last_status metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ Labels:
 
 Value: 0 or 1 depending on wherever the current state of each `dag_id` is `status`.
 
+### `airflow_task_last_status`
+
+Labels:
+
+* `dag_id`
+* `task_id`
+* `owner`
+* `status`
+
+Value: 0 or 1 depending on wherever the current state of each (`dag_id`, `task_id`) is `status`.
+
 ## License
 
 Distributed under the BSD license. See [LICENSE](LICENSE) for more

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -348,7 +348,7 @@ class MetricsCollector(object):
                             'dag_id': task.dag_id,
                             'task_id': task.task_id,
                             'owner': task.owner,
-                            'status': status,
+                            'status': status or 'none',
                             **labels
                         },
                         int(task.status == status)

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -134,7 +134,8 @@ def get_last_dagrun_task_info() -> List[TaskStatusInfo]:
     task_status_query = Session.query( # pylint: disable=no-member
         TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state,
         func.row_number().over(partition_by=(TaskInstance.dag_id, TaskInstance.task_id),
-                               order_by=TaskInstance.execution_date.desc()).label('row_number')
+                               order_by=(TaskInstance.execution_date.desc(),
+                                         TaskInstance._try_number.desc())).label('row_number')
     ).subquery()
 
     sql_res = Session.query( # pylint: disable=no-member

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -134,8 +134,7 @@ def get_last_dagrun_task_info() -> List[TaskStatusInfo]:
     task_status_query = Session.query( # pylint: disable=no-member
         TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state,
         func.row_number().over(partition_by=(TaskInstance.dag_id, TaskInstance.task_id),
-                               order_by=(TaskInstance.execution_date.desc(),
-                                         TaskInstance._try_number.desc())).label('row_number')
+                               order_by=TaskInstance.execution_date.desc()).label('row_number')
     ).subquery()
 
     sql_res = Session.query( # pylint: disable=no-member

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -342,13 +342,14 @@ class MetricsCollector(object):
             for task in tasks:
 
                 for status in State.task_states:
+                    status = status or 'none'
                     _add_gauge_metric(
                         task_last_status_metric,
                         {
                             'dag_id': task.dag_id,
                             'task_id': task.task_id,
                             'owner': task.owner,
-                            'status': status or 'none',
+                            'status': status,
                             **labels
                         },
                         int(task.status == status)

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -332,7 +332,7 @@ class MetricsCollector(object):
         # Task of last DagRun metrics
         task_last_status_metric = GaugeMetricFamily(
             'airflow_task_last_status',
-            'Shows the number of task starts with this status',
+            'Shows the status of task in the last dagrun',
             labels=['dag_id', 'task_id', 'owner', 'status']
         )
 


### PR DESCRIPTION
Similar with airflow_dag_last_status metric, airflow_task_last_status is status of tasks in the last dagrun of each dag. This metric can help to calculate the completion of the last dagrun (example: the dag is running, 50% of tasks are finished)

Result will look like this, for each task we will have 12 statuses:
![image](https://user-images.githubusercontent.com/16082537/121520234-e41e0600-ca1c-11eb-9280-c620ce9cda15.png)

