### PR TITLE
Add new metric - time from the last successful DAG run

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Labels:
 Value: duration in seconds of the longest DAG Run for given DAG. This metric 
 is not available for DAGs that have already finished.
 
+### `airflow_dag_elapsed_time`
+
+Labels:
+
+* `dag_id`: unique identifier for a given DAG
+
+Value: duration in seconds from the last successful dag run's start date.
+
+
 ### `airflow_dag_last_status`
 
 Labels:

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -160,7 +160,7 @@ def get_dag_duration_info() -> List[DagDurationInfo]:
         if driver in ('mysqldb', 'mysqlconnector', 'pysqlite'):
             dag_duration = i.duration
         else:
-            dag_duration = i.duration.seconds
+            dag_duration = i.duration.total_seconds()
 
         res.append(DagDurationInfo(
             dag_id = i.dag_id,


### PR DESCRIPTION
Hi there!
Thanks for the useful project!:)
We added a new metric for our needs which shows time duration from the last successful DAG run. Probably can be helpful for others, pls consider to merge it.

Also I made a small fix of dag_duration_metric.
