### PR TITLE
Add paused label for DAG status

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Labels:
 * `dag_id`
 * `owner`
 * `status`
+* `paused`
 
 Value: number of dags in a specific status.
 
@@ -94,6 +95,7 @@ Labels:
 * `dag_id`
 * `owner`
 * `status`
+* `paused`
 
 Value: 0 or 1 depending on wherever the current state of each `dag_id` is `status`.
 


### PR DESCRIPTION
Add label `paused` to `airflow_dag_status` and `airflow_dag_last_status`.

Relates to https://github.com/epoch8/airflow-exporter/issues/84