### PR TITLE
Fix the problem where customised `dag.params.labels` Dict cannot be considered in the dag labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## WIP
+
+- Fix the problem where customised dag.params.labels Dict cannot be considered
+  in the dag labels [#118](https://github.com/epoch8/airflow-exporter/pull/118)
+  by @zemin-piao
+
 ## 1.5.3
 
 - Fix Airflow 2.2.* compatiblity [#108](https://github.com/epoch8/airflow-exporter/issues/108)

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -200,9 +200,9 @@ def get_dag_labels(dag_id: str) -> Dict[str, str]:
 
     labels = dag.params.get('labels', {})
 
-    if hasattr(labels, 'value'):
+    if hasattr(labels, 'items'):
         # Airflow version 2.2.*
-        labels = {k:v for k,v in labels.value.items() if not k.startswith('__')}
+        labels = {k:v for k,v in labels.items() if not k.startswith('__')}
     else:
         # Airflow version 2.0.*, 2.1.*
         labels = labels.get('__var', {})

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -201,8 +201,11 @@ def get_dag_labels(dag_id: str) -> Dict[str, str]:
     labels = dag.params.get('labels', {})
 
     if hasattr(labels, 'items'):
-        # Airflow version 2.2.*
+        # Airflow version 2.3+
         labels = {k:v for k,v in labels.items() if not k.startswith('__')}
+    elif hasattr(labels, 'value'):
+        # Airflow version 2.2.*
+        labels = {k:v for k,v in labels.value.items() if not k.startswith('__')}
     else:
         # Airflow version 2.0.*, 2.1.*
         labels = labels.get('__var', {})


### PR DESCRIPTION
Fix the problem where customised `dag.params.labels` Dict cannot be considered in the dag labels