### PR TITLE
fix: use SerializedDagModel for dag labels instead of DagBag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## WIP 2.0.0
+
+- Use SerializedDagModel for dag labels instead of DagBag
+  [#131](https://github.com/epoch8/airflow-exporter/pull/131) by @ktaborski
+
 ## 1.7.0
 
 - Add `paused` label to DAG status metrics to indicate whether DAGs are paused

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -26,14 +26,6 @@ import logging
 log = logging.getLogger(__name__)
 use_fastapi = parse_version(airflow_version).major >= 3
 
-if use_fastapi:
-    from airflow.models.dagbag import DagBag
-
-    GLOBAL_DAGBAG = DagBag()
-else:
-    from flask import current_app
-
-
 @dataclass
 class DagStatusInfo:
     dag_id: str
@@ -237,17 +229,14 @@ def get_dag_duration_info() -> List[DagDurationInfo]:
 
 
 def get_dag_labels(dag_id: str) -> Dict[str, str]:
-    # reuse airflow webserver dagbag
-    dag = (
-        GLOBAL_DAGBAG.get_dag(dag_id)
-        if use_fastapi
-        else current_app.dag_bag.get_dag(dag_id)  # type: ignore
-    )
+    serialized_dag = SerializedDagModel.get_dag(dag_id)
 
-    if dag is None:
+    if serialized_dag is None or not serialized_dag.params:
         return dict()
 
-    labels = dag.params.get("labels", {})
+    # Use dump() to safely get params (suppresses validation errors)
+    params_dict = serialized_dag.params.dump()
+    labels = params_dict.get("labels", {})
 
     if hasattr(labels, "items"):
         # Airflow version 2.3+


### PR DESCRIPTION
Replace DagBag usage with SerializedDagModel.get_dag() to retrieve DAG labels. This approach uses the serialized DAG model which is more efficient and avoids maintaining a global DagBag instance. The change is compliant with Airflow 3 security model where DAG files should not exist locally on apiServer instances. The change also uses params.dump() method to safely extract parameters and suppress validation errors.

Changes:
- Remove global DagBag initialization for both FastAPI and Flask paths
- Use SerializedDagModel.get_dag() in get_dag_labels() function
- Add null check for serialized_dag.params before accessing
- Use params.dump() to safely get params dictionary