### PR TITLE
fix(get_last_dagrun_info): order the elements using updated_at != NULL instead of logical_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.1.0
+
+- Fix `airflow_dag_last_status` picking a manually triggered DAG run (which
+  has `logical_date` set to `NULL`) over the actual latest run. Order by
+  `updated_at` instead of `logical_date` when determining the last DAG run
+  [#137](https://github.com/epoch8/airflow-exporter/pull/137) by
+  @pierresouchay, fixes
+  [#136](https://github.com/epoch8/airflow-exporter/issues/136)
+
 ## 2.0.0
 
 - Drop support for Airflow < 3.0

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Labels:
 
 Value: 0 or 1 depending on wherever the current state of each `dag_id` is `status`.
 
+The "last" DAG run is the one with the most recent `updated_at` (not
+`logical_date`, which is `NULL` for manually triggered runs).
+
 ## License
 
 Distributed under the MIT license. See [LICENSE](LICENSE) for more

--- a/airflow_exporter/prometheus_exporter.py
+++ b/airflow_exporter/prometheus_exporter.py
@@ -76,7 +76,7 @@ def get_last_dagrun_info() -> List[DagStatusInfo]:
         DagRun.dag_id,
         DagRun.state,
         func.row_number()
-        .over(partition_by=DagRun.dag_id, order_by=DagRun.logical_date.desc())  # type: ignore
+        .over(partition_by=DagRun.dag_id, order_by=DagRun.updated_at.desc().nullslast())  # type: ignore
         .label("row_number"),
     ).subquery()
 


### PR DESCRIPTION
**Context**: when running manually, a dag_run has logical_date set to NULL and is returned first

**Solution**: rely instead of updated_at which is less likely to be null (actually never NULL with latest Airflow)

Will fix https://github.com/epoch8/airflow-exporter/issues/136